### PR TITLE
All changes to complete exercise

### DIFF
--- a/src/main/java/com/ecore/roles/exception/InvalidArgumentException.java
+++ b/src/main/java/com/ecore/roles/exception/InvalidArgumentException.java
@@ -7,4 +7,9 @@ public class InvalidArgumentException extends RuntimeException {
     public <T> InvalidArgumentException(Class<T> resource) {
         super(format("Invalid '%s' object", resource.getSimpleName()));
     }
+
+    // new constructor to provide detailed error message
+    public <T> InvalidArgumentException(Class<T> resource, String detailedMessage) {
+        super(format("Invalid '%s' object. %s", resource.getSimpleName(), detailedMessage));
+    }
 }

--- a/src/main/java/com/ecore/roles/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/ecore/roles/exception/ResourceNotFoundException.java
@@ -9,4 +9,8 @@ public class ResourceNotFoundException extends RuntimeException {
     public <T> ResourceNotFoundException(Class<T> resource, UUID id) {
         super(format("%s %s not found", resource.getSimpleName(), id));
     }
+
+    public <T> ResourceNotFoundException(Class<T> resource) {
+        super(format("No %s matches search criteria", resource.getSimpleName()));
+    }
 }

--- a/src/main/java/com/ecore/roles/repository/MembershipRepository.java
+++ b/src/main/java/com/ecore/roles/repository/MembershipRepository.java
@@ -1,14 +1,14 @@
 package com.ecore.roles.repository;
 
-import com.ecore.roles.model.Membership;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-@Repository
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ecore.roles.model.Membership;
+
+// removed superfluous @Repository annotation
 public interface MembershipRepository extends JpaRepository<Membership, UUID> {
 
     Optional<Membership> findByUserIdAndTeamId(UUID userId, UUID teamId);

--- a/src/main/java/com/ecore/roles/repository/RoleRepository.java
+++ b/src/main/java/com/ecore/roles/repository/RoleRepository.java
@@ -1,13 +1,13 @@
 package com.ecore.roles.repository;
 
-import com.ecore.roles.model.Role;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
 import java.util.UUID;
 
-@Repository
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ecore.roles.model.Role;
+
+// removed superfluous @Repository annotation
 public interface RoleRepository extends JpaRepository<Role, UUID> {
     Optional<Role> findByName(String name);
 }

--- a/src/main/java/com/ecore/roles/service/RolesService.java
+++ b/src/main/java/com/ecore/roles/service/RolesService.java
@@ -7,10 +7,11 @@ import java.util.UUID;
 
 public interface RolesService {
 
-    Role CreateRole(Role role);
+    Role createRole(Role role);
 
-    Role GetRole(UUID id);
+    Role getRole(UUID id);
 
-    List<Role> GetRoles();
+    List<Role> getRoles();
 
+    Role getRole(UUID userId, UUID teamId);
 }

--- a/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
@@ -1,5 +1,14 @@
 package com.ecore.roles.service.impl;
 
+import static java.util.Optional.ofNullable;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.ecore.roles.client.model.Team;
 import com.ecore.roles.exception.InvalidArgumentException;
 import com.ecore.roles.exception.ResourceExistsException;
 import com.ecore.roles.exception.ResourceNotFoundException;
@@ -8,33 +17,44 @@ import com.ecore.roles.model.Role;
 import com.ecore.roles.repository.MembershipRepository;
 import com.ecore.roles.repository.RoleRepository;
 import com.ecore.roles.service.MembershipsService;
+import com.ecore.roles.service.TeamsService;
+
 import lombok.NonNull;
-import lombok.extern.log4j.Log4j2;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.UUID;
-
-import static java.util.Optional.ofNullable;
-
-@Log4j2
+// Removed unused @Log4j2 annotation
 @Service
 public class MembershipsServiceImpl implements MembershipsService {
 
     private final MembershipRepository membershipRepository;
     private final RoleRepository roleRepository;
+    // added TeamsClient object to validate teams
+    private final TeamsService teamsService;
 
-    @Autowired
+    // Removed superfluous @Autowired annotation
     public MembershipsServiceImpl(
             MembershipRepository membershipRepository,
-            RoleRepository roleRepository) {
+            RoleRepository roleRepository,
+            // added TeamsClient parameter for injection
+            TeamsService teamsService) {
         this.membershipRepository = membershipRepository;
         this.roleRepository = roleRepository;
+        this.teamsService = teamsService;
     }
 
     @Override
     public Membership assignRoleToMembership(@NonNull Membership m) {
+        // added team validation login
+        Team team = teamsService.getTeam(m.getTeamId());
+
+        if (Objects.isNull(team)) {
+            throw new ResourceNotFoundException(Team.class, m.getTeamId());
+        }
+        
+        // added user team member validation
+        if (!team.getTeamMemberIds().contains(m.getUserId())) {
+            throw new InvalidArgumentException(Membership.class, 
+                    "The provided user doesn't belong to the provided team.");
+        }
 
         UUID roleId = ofNullable(m.getRole()).map(Role::getId)
                 .orElseThrow(() -> new InvalidArgumentException(Role.class));

--- a/src/main/java/com/ecore/roles/service/impl/RolesServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/RolesServiceImpl.java
@@ -1,21 +1,27 @@
 package com.ecore.roles.service.impl;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.ecore.roles.client.model.Team;
+import com.ecore.roles.client.model.User;
+import com.ecore.roles.exception.InvalidArgumentException;
 import com.ecore.roles.exception.ResourceExistsException;
 import com.ecore.roles.exception.ResourceNotFoundException;
+import com.ecore.roles.model.Membership;
 import com.ecore.roles.model.Role;
 import com.ecore.roles.repository.MembershipRepository;
 import com.ecore.roles.repository.RoleRepository;
-import com.ecore.roles.service.MembershipsService;
 import com.ecore.roles.service.RolesService;
+import com.ecore.roles.service.TeamsService;
+import com.ecore.roles.service.UsersService;
+
 import lombok.NonNull;
-import lombok.extern.log4j.Log4j2;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.UUID;
-
-@Log4j2
+// Removed unused @Log4j2 annotation
 @Service
 public class RolesServiceImpl implements RolesService {
 
@@ -23,20 +29,24 @@ public class RolesServiceImpl implements RolesService {
 
     private final RoleRepository roleRepository;
     private final MembershipRepository membershipRepository;
-    private final MembershipsService membershipsService;
+    private final TeamsService teamsService;
+    private final UsersService usersService;
 
-    @Autowired
+    // Removed superfluous @Autowired annotation
     public RolesServiceImpl(
             RoleRepository roleRepository,
             MembershipRepository membershipRepository,
-            MembershipsService membershipsService) {
+            TeamsService teamsService,
+            UsersService usersService) {
         this.roleRepository = roleRepository;
         this.membershipRepository = membershipRepository;
-        this.membershipsService = membershipsService;
+        this.teamsService = teamsService;
+        this.usersService = usersService;
     }
 
     @Override
-    public Role CreateRole(@NonNull Role r) {
+    // renamed method to keep naming convention
+    public Role createRole(@NonNull Role r) {
         if (roleRepository.findByName(r.getName()).isPresent()) {
             throw new ResourceExistsException(Role.class);
         }
@@ -44,18 +54,45 @@ public class RolesServiceImpl implements RolesService {
     }
 
     @Override
-    public Role GetRole(@NonNull UUID rid) {
+    // renamed method to keep naming convention
+    public Role getRole(@NonNull UUID rid) {
         return roleRepository.findById(rid)
                 .orElseThrow(() -> new ResourceNotFoundException(Role.class, rid));
     }
 
     @Override
-    public List<Role> GetRoles() {
+    // renamed method to keep naming convention
+    public List<Role> getRoles() {
         return roleRepository.findAll();
     }
 
-    private Role getDefaultRole() {
-        return roleRepository.findByName(DEFAULT_ROLE)
-                .orElseThrow(() -> new IllegalStateException("Default role is not configured"));
+    // new method to get role by user id and team id
+    @Override
+    public Role getRole(UUID userId, UUID teamId) {
+        // validate user exists
+        User user = usersService.getUser(userId);
+
+        if (Objects.isNull(user)) {
+            throw new ResourceNotFoundException(User.class, userId);
+        }
+
+        // validate team exists
+        Team team = teamsService.getTeam(teamId);
+
+        if (Objects.isNull(team)) {
+            throw new ResourceNotFoundException(Team.class, teamId);
+        }
+
+        // validate user belongs to team
+        if (!team.getTeamMemberIds().contains(userId)) {
+            throw new InvalidArgumentException(User.class,
+                "The provided user doesn't belong to the provided team.");
+        }
+
+        return membershipRepository.findByUserIdAndTeamId(userId, teamId)
+                .map(m -> m.getRole())
+                .orElseThrow(() -> new ResourceNotFoundException(Membership.class));
     }
+
+    // removed unused getDefaultRole method
 }

--- a/src/main/java/com/ecore/roles/service/impl/TeamsServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/TeamsServiceImpl.java
@@ -1,20 +1,20 @@
 package com.ecore.roles.service.impl;
 
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
 import com.ecore.roles.client.TeamsClient;
 import com.ecore.roles.client.model.Team;
 import com.ecore.roles.service.TeamsService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.UUID;
 
 @Service
 public class TeamsServiceImpl implements TeamsService {
 
     private final TeamsClient teamsClient;
 
-    @Autowired
+    // Removed superfluous @Autowired annotation
     public TeamsServiceImpl(TeamsClient teamsClient) {
         this.teamsClient = teamsClient;
     }

--- a/src/main/java/com/ecore/roles/service/impl/UsersServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/UsersServiceImpl.java
@@ -1,20 +1,20 @@
 package com.ecore.roles.service.impl;
 
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
 import com.ecore.roles.client.UsersClient;
 import com.ecore.roles.client.model.User;
 import com.ecore.roles.service.UsersService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.UUID;
 
 @Service
 public class UsersServiceImpl implements UsersService {
 
     private final UsersClient usersClient;
 
-    @Autowired
+    // removed superfluous @Autowired annotation
     public UsersServiceImpl(UsersClient usersClient) {
         this.usersClient = usersClient;
     }

--- a/src/main/java/com/ecore/roles/web/RolesApi.java
+++ b/src/main/java/com/ecore/roles/web/RolesApi.java
@@ -14,6 +14,9 @@ public interface RolesApi {
     ResponseEntity<List<RoleDto>> getRoles();
 
     ResponseEntity<RoleDto> getRole(
+            UUID teamMemberUuid, UUID teamUuid);
+
+    ResponseEntity<RoleDto> getRole(
             UUID roleId);
 
 }

--- a/src/main/java/com/ecore/roles/web/rest/DefaultExceptionHandler.java
+++ b/src/main/java/com/ecore/roles/web/rest/DefaultExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.ecore.roles.web.rest;
 
 import com.ecore.roles.exception.ErrorResponse;
+import com.ecore.roles.exception.InvalidArgumentException;
 import com.ecore.roles.exception.ResourceExistsException;
 import com.ecore.roles.exception.ResourceNotFoundException;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,12 @@ public class DefaultExceptionHandler {
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> handle(IllegalStateException exception) {
         return createResponse(500, exception.getMessage());
+    }
+
+    // new handler for InvalidArgumentExceptions
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handle(InvalidArgumentException exception) {
+        return createResponse(400, exception.getMessage());
     }
 
     private ResponseEntity<ErrorResponse> createResponse(int status, String exception) {

--- a/src/main/java/com/ecore/roles/web/rest/MembershipsRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/MembershipsRestController.java
@@ -1,19 +1,28 @@
 package com.ecore.roles.web.rest;
 
+import static com.ecore.roles.web.dto.MembershipDto.fromModel;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.ecore.roles.model.Membership;
 import com.ecore.roles.service.MembershipsService;
 import com.ecore.roles.web.MembershipsApi;
 import com.ecore.roles.web.dto.MembershipDto;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 
-import static com.ecore.roles.web.dto.MembershipDto.fromModel;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
@@ -30,12 +39,12 @@ public class MembershipsRestController implements MembershipsApi {
             @NotNull @Valid @RequestBody MembershipDto membershipDto) {
         Membership membership = membershipsService.assignRoleToMembership(membershipDto.toModel());
         return ResponseEntity
-                .status(200)
+                .status(201) // Changed response status to 201 CREATED
                 .body(fromModel(membership));
     }
 
     @Override
-    @PostMapping(
+    @GetMapping( // changed to GET Mapping, the appropriate HTTP method for retrieving data
             path = "/search",
             produces = {"application/json"})
     public ResponseEntity<List<MembershipDto>> getMemberships(
@@ -43,12 +52,10 @@ public class MembershipsRestController implements MembershipsApi {
 
         List<Membership> memberships = membershipsService.getMemberships(roleId);
 
-        List<MembershipDto> newMembershipDto = new ArrayList<>();
-
-        for (Membership membership : memberships) {
-            MembershipDto membershipDto = fromModel(membership);
-            newMembershipDto.add(membershipDto);
-        }
+        // changed to use Stream API
+        List<MembershipDto> newMembershipDto = memberships.stream()
+                        .map(m -> fromModel(m))
+                        .collect(Collectors.toList());
 
         return ResponseEntity
                 .status(200)

--- a/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
@@ -1,19 +1,29 @@
 package com.ecore.roles.web.rest;
 
+import static com.ecore.roles.web.dto.RoleDto.fromModel;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.ecore.roles.model.Role;
 import com.ecore.roles.service.RolesService;
 import com.ecore.roles.web.RolesApi;
 import com.ecore.roles.web.dto.RoleDto;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import javax.validation.Valid;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
-import static com.ecore.roles.web.dto.RoleDto.fromModel;
 
 @RequiredArgsConstructor
 @RestController
@@ -29,38 +39,50 @@ public class RolesRestController implements RolesApi {
     public ResponseEntity<RoleDto> createRole(
             @Valid @RequestBody RoleDto role) {
         return ResponseEntity
-                .status(200)
-                .body(fromModel(rolesService.CreateRole(role.toModel())));
+                .status(201) // changed response status to 201 CREATED
+                .body(fromModel(rolesService.createRole(role.toModel())));
     }
 
     @Override
-    @PostMapping(
+    @GetMapping( // changed to GET Mapping, the appropriate HTTP method for retrieving data
             produces = {"application/json"})
     public ResponseEntity<List<RoleDto>> getRoles() {
 
-        List<Role> getRoles = rolesService.GetRoles();
+        // changed variable name to clarify
+        List<Role> roles = rolesService.getRoles();
 
-        List<RoleDto> roleDtoList = new ArrayList<>();
-
-        for (Role role : getRoles) {
-            RoleDto roleDto = fromModel(role);
-            roleDtoList.add(roleDto);
-        }
+        // changed to use Stream API
+        List<RoleDto> roleDtoList = roles.stream()
+                .map(r -> fromModel(r))
+                .collect(Collectors.toList());
 
         return ResponseEntity
                 .status(200)
                 .body(roleDtoList);
     }
 
+    // new endpoint to search Role by UserId and TeamId
     @Override
-    @PostMapping(
+    @GetMapping(
+            path = "/search",
+            produces = {"application/json"})
+    public ResponseEntity<RoleDto> getRole(
+            @RequestParam @NotNull UUID teamMemberId,
+            @RequestParam @NotNull UUID teamId) {
+        return ResponseEntity
+                .status(200)
+                .body(fromModel(rolesService.getRole(teamMemberId, teamId)));
+    }
+
+    @Override
+    @GetMapping( // changed to GET Mapping, the appropriate HTTP method for retrieving data
             path = "/{roleId}",
             produces = {"application/json"})
     public ResponseEntity<RoleDto> getRole(
             @PathVariable UUID roleId) {
         return ResponseEntity
                 .status(200)
-                .body(fromModel(rolesService.GetRole(roleId)));
+                .body(fromModel(rolesService.getRole(roleId)));
     }
 
 }

--- a/src/main/java/com/ecore/roles/web/rest/TeamsRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/TeamsRestController.java
@@ -1,20 +1,23 @@
 package com.ecore.roles.web.rest;
 
-import com.ecore.roles.service.TeamsService;
-import com.ecore.roles.web.TeamsApi;
-import com.ecore.roles.web.dto.TeamDto;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import static com.ecore.roles.web.dto.TeamDto.fromModel;
 
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static com.ecore.roles.web.dto.TeamDto.fromModel;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ecore.roles.service.TeamsService;
+import com.ecore.roles.web.TeamsApi;
+import com.ecore.roles.web.dto.TeamDto;
+
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
@@ -35,7 +38,7 @@ public class TeamsRestController implements TeamsApi {
     }
 
     @Override
-    @PostMapping(
+    @GetMapping( // changed to GET Mapping, the appropriate HTTP method for retrieving data
             path = "/{teamId}",
             produces = {"application/json"})
     public ResponseEntity<TeamDto> getTeam(

--- a/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
@@ -14,8 +14,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
-import static com.ecore.roles.utils.TestData.DEFAULT_MEMBERSHIP;
-import static com.ecore.roles.utils.TestData.DEVELOPER_ROLE;
+import static com.ecore.roles.utils.TestData.buildDefaultMembership;
+import static com.ecore.roles.utils.TestData.buildDeveloperRole;
+import static com.ecore.roles.utils.TestData.buildOrdinaryCoralLynxTeam;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -39,16 +40,20 @@ class MembershipsServiceTest {
     private TeamsService teamsService;
 
     @Test
-    public void shouldCreateMembership() {
-        Membership expectedMembership = DEFAULT_MEMBERSHIP();
+    // removed public access modifier
+    void shouldCreateMembership() {
+        Membership expectedMembership = buildDefaultMembership();
         when(roleRepository.findById(expectedMembership.getRole().getId()))
-                .thenReturn(Optional.ofNullable(DEVELOPER_ROLE()));
+                .thenReturn(Optional.ofNullable(buildDeveloperRole()));
         when(membershipRepository.findByUserIdAndTeamId(expectedMembership.getUserId(),
                 expectedMembership.getTeamId()))
                         .thenReturn(Optional.empty());
         when(membershipRepository
                 .save(expectedMembership))
                         .thenReturn(expectedMembership);
+        // added mock return to pass new Team validation
+        when(teamsService.getTeam(expectedMembership.getTeamId()))
+                .thenReturn(buildOrdinaryCoralLynxTeam());
 
         Membership actualMembership = membershipsService.assignRoleToMembership(expectedMembership);
 
@@ -58,17 +63,22 @@ class MembershipsServiceTest {
     }
 
     @Test
-    public void shouldFailToCreateMembershipWhenMembershipsIsNull() {
+    // removed public access modifier
+    void shouldFailToCreateMembershipWhenMembershipsIsNull() {
         assertThrows(NullPointerException.class,
                 () -> membershipsService.assignRoleToMembership(null));
     }
 
     @Test
-    public void shouldFailToCreateMembershipWhenItExists() {
-        Membership expectedMembership = DEFAULT_MEMBERSHIP();
+    // removed public access modifier
+    void shouldFailToCreateMembershipWhenItExists() {
+        Membership expectedMembership = buildDefaultMembership();
         when(membershipRepository.findByUserIdAndTeamId(expectedMembership.getUserId(),
                 expectedMembership.getTeamId()))
                         .thenReturn(Optional.of(expectedMembership));
+        // added mock return to pass new Team validation
+        when(teamsService.getTeam(expectedMembership.getTeamId()))
+                .thenReturn(buildOrdinaryCoralLynxTeam());
 
         ResourceExistsException exception = assertThrows(ResourceExistsException.class,
                 () -> membershipsService.assignRoleToMembership(expectedMembership));
@@ -76,13 +86,17 @@ class MembershipsServiceTest {
         assertEquals("Membership already exists", exception.getMessage());
         verify(roleRepository, times(0)).getById(any());
         verify(usersService, times(0)).getUser(any());
-        verify(teamsService, times(0)).getTeam(any());
+        verify(teamsService, times(1)).getTeam(any());
     }
 
     @Test
-    public void shouldFailToCreateMembershipWhenItHasInvalidRole() {
-        Membership expectedMembership = DEFAULT_MEMBERSHIP();
+    // removed public access modifier
+    void shouldFailToCreateMembershipWhenItHasInvalidRole() {
+        Membership expectedMembership = buildDefaultMembership();
         expectedMembership.setRole(null);
+        // added mock return to pass new Team validation
+        when(teamsService.getTeam(expectedMembership.getTeamId()))
+                .thenReturn(buildOrdinaryCoralLynxTeam());
 
         InvalidArgumentException exception = assertThrows(InvalidArgumentException.class,
                 () -> membershipsService.assignRoleToMembership(expectedMembership));
@@ -91,13 +105,13 @@ class MembershipsServiceTest {
         verify(membershipRepository, times(0)).findByUserIdAndTeamId(any(), any());
         verify(roleRepository, times(0)).getById(any());
         verify(usersService, times(0)).getUser(any());
-        verify(teamsService, times(0)).getTeam(any());
+        verify(teamsService, times(1)).getTeam(any());
     }
 
     @Test
-    public void shouldFailToGetMembershipsWhenRoleIdIsNull() {
+    // removed public access modifier
+    void shouldFailToGetMembershipsWhenRoleIdIsNull() {
         assertThrows(NullPointerException.class,
                 () -> membershipsService.getMemberships(null));
     }
-
 }

--- a/src/test/java/com/ecore/roles/service/RolesServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/RolesServiceTest.java
@@ -1,25 +1,36 @@
 package com.ecore.roles.service;
 
-import com.ecore.roles.exception.ResourceNotFoundException;
-import com.ecore.roles.model.Role;
-import com.ecore.roles.repository.MembershipRepository;
-import com.ecore.roles.repository.RoleRepository;
-import com.ecore.roles.service.impl.RolesServiceImpl;
+import static com.ecore.roles.utils.TestData.UUID_1;
+import static com.ecore.roles.utils.TestData.buildDefaultMembership;
+import static com.ecore.roles.utils.TestData.buildDeveloperRole;
+import static com.ecore.roles.utils.TestData.buildGianniUser;
+import static com.ecore.roles.utils.TestData.buildOrdinaryCoralLynxTeam;
+import static com.ecore.roles.utils.TestData.buildUserWithoutMembership;
+import static java.lang.String.format;
+import static java.util.Optional.of;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-
-import static com.ecore.roles.utils.TestData.DEVELOPER_ROLE;
-import static com.ecore.roles.utils.TestData.UUID_1;
-import static java.lang.String.format;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
+import com.ecore.roles.client.model.Team;
+import com.ecore.roles.client.model.User;
+import com.ecore.roles.exception.InvalidArgumentException;
+import com.ecore.roles.exception.ResourceNotFoundException;
+import com.ecore.roles.model.Membership;
+import com.ecore.roles.model.Role;
+import com.ecore.roles.repository.MembershipRepository;
+import com.ecore.roles.repository.RoleRepository;
+import com.ecore.roles.service.impl.RolesServiceImpl;
 
 @ExtendWith(MockitoExtension.class)
 class RolesServiceTest {
@@ -33,42 +44,98 @@ class RolesServiceTest {
     @Mock
     private MembershipRepository membershipRepository;
 
+    // removed unused MembershipsService
+
+    // added TeamsService and UsersService mocks
     @Mock
-    private MembershipsService membershipsService;
+    private TeamsService teamsService;
+
+    @Mock
+    private UsersService usersService;
 
     @Test
-    public void shouldCreateRole() {
-        Role developerRole = DEVELOPER_ROLE();
+    // removed public access modifier
+    void shouldCreateRole() {
+        Role developerRole = buildDeveloperRole();
         when(roleRepository.save(developerRole)).thenReturn(developerRole);
 
-        Role role = rolesService.CreateRole(developerRole);
+        Role role = rolesService.createRole(developerRole);
 
         assertNotNull(role);
         assertEquals(developerRole, role);
     }
 
     @Test
-    public void shouldFailToCreateRoleWhenRoleIsNull() {
+    // removed public access modifier
+    void shouldFailToCreateRoleWhenRoleIsNull() {
         assertThrows(NullPointerException.class,
-                () -> rolesService.CreateRole(null));
+                () -> rolesService.createRole(null));
     }
 
     @Test
-    public void shouldReturnRoleWhenRoleIdExists() {
-        Role developerRole = DEVELOPER_ROLE();
+    // removed public access modifier
+    void shouldReturnRoleWhenRoleIdExists() {
+        Role developerRole = buildDeveloperRole();
         when(roleRepository.findById(developerRole.getId())).thenReturn(Optional.of(developerRole));
 
-        Role role = rolesService.GetRole(developerRole.getId());
+        Role role = rolesService.getRole(developerRole.getId());
 
         assertNotNull(role);
         assertEquals(developerRole, role);
     }
 
     @Test
-    public void shouldFailToGetRoleWhenRoleIdDoesNotExist() {
+    // removed public access modifier
+    void shouldFailToGetRoleWhenRoleIdDoesNotExist() {
         ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
-                () -> rolesService.GetRole(UUID_1));
+                () -> rolesService.getRole(UUID_1));
 
         assertEquals(format("Role %s not found", UUID_1), exception.getMessage());
+    }
+
+    // new test cases for new getRole(UUID, UUID) method
+    @Test
+    void shouldFailToGetRoleByUserIdAndTeamIdWhenUserIdIsNull() {
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
+                () -> rolesService.getRole(null, UUID_1));
+        assertEquals("User null not found", exception.getMessage());
+    }
+
+    @Test
+    void shouldFailToGetRoleByUserIdAndTeamIdWhenTeamIdIsNull() {
+        User user = buildUserWithoutMembership();
+        UUID userId = user.getId();
+        when(usersService.getUser(userId)).thenReturn(user);
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
+                () -> rolesService.getRole(userId, null));
+        assertEquals("Team null not found", exception.getMessage());
+    }
+
+    @Test
+    void shouldFailToGetRoleByUserIdAndTeamIdWhenUserDoesntBelongToTeam() {
+        User user = buildUserWithoutMembership();
+        UUID userId = user.getId();
+        Team team = buildOrdinaryCoralLynxTeam();
+        UUID teamId = team.getId();
+        when(usersService.getUser(userId)).thenReturn(user);
+        when(teamsService.getTeam(teamId)).thenReturn(team);
+        InvalidArgumentException exception = assertThrows(InvalidArgumentException.class,
+                () -> rolesService.getRole(userId, teamId));
+        assertEquals("Invalid 'User' object. The provided user doesn't belong to the provided team.", exception.getMessage());
+    }
+
+    @Test
+    void shouldGetRoleByUserIdAndTeamId() {
+        Role developerRole = buildDeveloperRole();
+        User user = buildGianniUser();
+        Team team = buildOrdinaryCoralLynxTeam();
+        Membership membership = buildDefaultMembership();
+        when(usersService.getUser(user.getId())).thenReturn(user);
+        when(teamsService.getTeam(team.getId())).thenReturn(team);
+        when(membershipRepository.findByUserIdAndTeamId(user.getId(), team.getId()))
+                .thenReturn(of(membership));
+        Role role = rolesService.getRole(user.getId(), team.getId());
+        assertNotNull(role);
+        assertEquals(developerRole.getName(), role.getName());
     }
 }

--- a/src/test/java/com/ecore/roles/service/TeamsServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/TeamsServiceTest.java
@@ -11,7 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import static com.ecore.roles.utils.TestData.ORDINARY_CORAL_LYNX_TEAM;
+import static com.ecore.roles.utils.TestData.buildOrdinaryCoralLynxTeam;
 import static com.ecore.roles.utils.TestData.ORDINARY_CORAL_LYNX_TEAM_UUID;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
@@ -26,7 +26,7 @@ class TeamsServiceTest {
 
     @Test
     void shouldGetTeamWhenTeamIdExists() {
-        Team ordinaryCoralLynxTeam = ORDINARY_CORAL_LYNX_TEAM();
+        Team ordinaryCoralLynxTeam = buildOrdinaryCoralLynxTeam();
         when(TeamsClient.getTeam(ORDINARY_CORAL_LYNX_TEAM_UUID))
                 .thenReturn(ResponseEntity
                         .status(HttpStatus.OK)

--- a/src/test/java/com/ecore/roles/service/UsersServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/UsersServiceTest.java
@@ -11,7 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import static com.ecore.roles.utils.TestData.GIANNI_USER;
+import static com.ecore.roles.utils.TestData.buildGianniUser;
 import static com.ecore.roles.utils.TestData.UUID_1;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
@@ -26,7 +26,7 @@ class UsersServiceTest {
 
     @Test
     void shouldGetUserWhenUserIdExists() {
-        User gianniUser = GIANNI_USER();
+        User gianniUser = buildGianniUser();
         when(usersClient.getUser(UUID_1))
                 .thenReturn(ResponseEntity
                         .status(HttpStatus.OK)

--- a/src/test/java/com/ecore/roles/utils/MockUtils.java
+++ b/src/test/java/com/ecore/roles/utils/MockUtils.java
@@ -20,7 +20,7 @@ public class MockUtils {
 
     public static void mockGetUserById(MockRestServiceServer mockServer, UUID userId, User user) {
         try {
-            mockServer.expect(requestTo("http://test.com/users/" + userId))
+            mockServer.expect(ExpectedCount.manyTimes(), requestTo("http://test.com/users/" + userId))
                     .andExpect(method(HttpMethod.GET))
                     .andRespond(
                             withStatus(HttpStatus.OK)

--- a/src/test/java/com/ecore/roles/utils/TestData.java
+++ b/src/test/java/com/ecore/roles/utils/TestData.java
@@ -27,30 +27,30 @@ public class TestData {
     public static final UUID DEFAULT_MEMBERSHIP_UUID =
             UUID.fromString("98de61a0-b9e3-11ec-8422-0242ac120002");
 
-    public static Role DEVELOPER_ROLE() {
+    public static Role buildDeveloperRole() { // renamed to keep method naming convention
         return Role.builder()
                 .id(DEVELOPER_ROLE_UUID)
                 .name("Developer").build();
     }
 
-    public static Role PRODUCT_OWNER_ROLE() {
+    public static Role buildProductOwnerRole() { // renamed to keep method naming convention
         return Role.builder()
                 .id(PRODUCT_OWNER_UUID)
                 .name("Product Owner").build();
     }
 
-    public static Role TESTER_ROLE() {
+    public static Role buildTesterRole() { // renamed to keep method naming convention
         return Role.builder()
                 .id(TESTER_ROLE_UUID)
                 .name("Tester").build();
     }
 
-    public static Role DEVOPS_ROLE() {
+    public static Role buildDevopsRole() { // renamed to keep method naming convention
         return Role.builder()
                 .name("DevOps").build();
     }
 
-    public static Team ORDINARY_CORAL_LYNX_TEAM(boolean full) {
+    public static Team buildOrdinaryCoralLynxTeam(boolean full) { // renamed to keep method naming convention
         Team team = Team.builder()
                 .id(ORDINARY_CORAL_LYNX_TEAM_UUID)
                 .name("System Team").build();
@@ -61,11 +61,11 @@ public class TestData {
         return team;
     }
 
-    public static Team ORDINARY_CORAL_LYNX_TEAM() {
-        return ORDINARY_CORAL_LYNX_TEAM(true);
+    public static Team buildOrdinaryCoralLynxTeam() { // renamed to keep method naming convention
+        return buildOrdinaryCoralLynxTeam(true);
     }
 
-    public static User GIANNI_USER(boolean full) {
+    public static User buildGianniUser(boolean full) { // renamed to keep method naming convention
         User user = User.builder()
                 .id(GIANNI_USER_UUID)
                 .displayName("gianniWehner").build();
@@ -78,23 +78,31 @@ public class TestData {
         return user;
     }
 
-    public static User GIANNI_USER() {
-        return GIANNI_USER(true);
+    public static User buildGianniUser() { // renamed to keep method naming convention
+        return buildGianniUser(true);
     }
 
-    public static Membership DEFAULT_MEMBERSHIP() {
+    // new method to create a User that doesn't belong to Coral Lynx Team
+    public static User buildUserWithoutMembership() {
+        return User.builder()
+                .id(UUID_4)
+                .displayName("notAMember")
+                .build();
+    }
+
+    public static Membership buildDefaultMembership() { // renamed to keep method naming convention
         return Membership.builder()
                 .id(DEFAULT_MEMBERSHIP_UUID)
-                .role(DEVELOPER_ROLE())
+                .role(buildDeveloperRole())
                 .userId(GIANNI_USER_UUID)
                 .teamId(ORDINARY_CORAL_LYNX_TEAM_UUID)
                 .build();
     }
 
-    public static Membership INVALID_MEMBERSHIP() {
+    public static Membership buildInvalidMembership() { // renamed to keep method naming convention
         return Membership.builder()
                 .id(DEFAULT_MEMBERSHIP_UUID)
-                .role(DEVELOPER_ROLE())
+                .role(buildDeveloperRole())
                 .userId(UUID_4)
                 .teamId(ORDINARY_CORAL_LYNX_TEAM_UUID)
                 .build();


### PR DESCRIPTION
**src/main/java/com/ecore/roles/exception/InvalidArgumentException.java:**
- Created a new constructor to accept more details for the exception message.

**src/main/java/com/ecore/roles/exception/ResourceNotFoundException.java:**
- Created a new constructor that doesn't take an Id argument, for searches on different criteria that return no results.

**src/main/java/com/ecore/roles/repository/MembershipRepository.java:**
- Removed @Repository annotation, as it is not needed for classes that extend JpaRepository

**src/main/java/com/ecore/roles/repository/RoleRepository.java:**
- Removed @Repository annotation, as it is not needed for classes that extend JpaRepository

**src/main/java/com/ecore/roles/service/RolesService.java:**
- Changed method names to comply with camel case, the convention for Java methods
- Added new method getRoles(UUID userId, UUID teamId) to retrieve a role by user and team ids

**src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java:**
- Removed @Log4j2 annotation as it was not used
- Removed @Autowired annotation as it is not needed
- Added new TeamsService attribute to validate team id exists and user belongs to team in assignRoleToMembership method

**src/main/java/com/ecore/roles/service/impl/RolesServiceImpl.java:**
- Removed @Log4j2 annotation as it was not used
- Removed @Autowired annotation as it is not needed
- Added new UsersService attribute to validate user id exists in new getRole method
- Added new TeamsService attribute to validate team Id exists and user belongs to Team in new getRole method
- Renamed previously existing methods to comply with camel case, the convention for Java methods
- Deleted getDefaultRole method as it was unused

**src/main/java/com/ecore/roles/service/impl/TeamsServiceImpl.java:**
- Removed @Autowired annotation as it is not needed

**src/main/java/com/ecore/roles/service/impl/UsersServiceImpl.java:**
- Removed @Autowired annotation as it is not needed

**src/main/java/com/ecore/roles/web/RolesApi.java:**
- Added new method getRole(UUID userId, UUID teamId) to the interface

**src/main/java/com/ecore/roles/web/rest/DefaultExceptionHandler.java:**
- Added new exception handler method to handle InvalidArgumentExceptions

**src/main/java/com/ecore/roles/web/rest/MembershipsRestController.java:**
- Changed HTTP response status to a more appropriate 201 CREATED in method assignRoleToMembership()
- Changed endpoint mapping from POST to GET for method getMemberships as it is the correct method for retrieving data
- Changed getMemberships method implementation to use more concise Stream API

**src/main/java/com/ecore/roles/web/rest/RolesRestController.java:**
- Changed HTTP response status to a more appropriate 201 CREATED in method createRole()
- Changed endpoint mapping from POST to GET for method getRoles as it is the correct method for retrieving data
- Changed endpoint mapping from POST to GET for method getRole as it is the correct method for retrieving data
- Changed getRoles method implementation to use more concise Stream API
- Updated rolesService method calls to use new corrected method names
- Created new GET endpoint getRole(UUID userId, UUID teamID) to retrieve role by user id and team id

**src/main/java/com/ecore/roles/web/rest/TeamsRestController.java:**
- Changed endpoint mapping from POST to GET for method getTeam as it is the correct method for retrieving data

**src/test/java/com/ecore/roles/api/MembershipsApiTests.java:**
- Removed public access modifier from Test class
- Updated calls to TestData static methods to use new corrected method names
- Added mock server calls to pass new team validation in test method shouldFailToCreateRoleMembershipWhenRoleDoesNotExist
- Changed assertions to be more meaningful in test method shouldGetAllMemberships

**src/test/java/com/ecore/roles/api/RolesApiTest.java:**
- Removed public access modifier from Test class
- Updated calls to TestData static methods to use new corrected method names
- Chained assertions and changed to more meaningful method in test method shouldGetAllRoles
- Added mock server calls to pass new user validation in test methods shouldGetRoleByUserIdAndTeamId and shouldFailToGetRoleByUserIdAndTeamIdWhenItDoesNotExist
- Added new test method shouldFailToGetRoleByUserIdAndTeamIdWhenUserDoesntBelongToTeam

**src/test/java/com/ecore/roles/service/MembershipsServiceTest.java:**
- Removed public access modifier from all test methods
- Updated calls to TestData static methods to use new corrected method names
- Added mock server calls to pass new team validation in membershipsService.assignRoleToMembership() method in test methods shouldCreateMembership, shouldFailToCreateMembershipWhenItExists and shouldFailToCreateMembershipWhenItHasInvalidRole
- Changed verify number of calls to teamsService.getTeam method to 1 in test methods shouldFailToCreateMembershipWhenItExists and shouldFailToCreateMembershipWhenItHasInvalidRole

**src/test/java/com/ecore/roles/service/RolesServiceTest.java:**
- Removed public access modifier from all test methods
- Updated calls to TestData static methods to use new corrected method names
- Removed unused mock MembershipsService
- Added TeamsService and UsersService mocks
- Updated calls to RolesService methods to use new corrected method names
- Added new test methods shouldFailToGetRoleByUserIdAndTeamIdWhenUserIdIsNull, shouldFailToGetRoleByUserIdAndTeamIdWhenTeamIdIsNull, shouldFailToGetRoleByUserIdAndTeamIdWhenUserDoesntBelongToTeam, shouldGetRoleByUserIdAndTeamId

**src/test/java/com/ecore/roles/service/TeamsServiceTest.java:**
- Updated calls to TestData static methods to use new corrected method names

**src/test/java/com/ecore/roles/service/UsersServiceTest.java:**
- Updated calls to TestData static methods to use new corrected method names

**src/test/java/com/ecore/roles/utils/MockUtils.java:**
- Changed mock server response to many times in mockGetUserById method

**src/test/java/com/ecore/roles/utils/TestData.java:**
- Changed method names to comply with camel case, the convention for Java methods, and to be more meaningful
- Created new method buildUserWithoutMembership to build an User that doesn't belong to Coral Lynx Team